### PR TITLE
Fixed content errors

### DIFF
--- a/content/blocks/liquid/benthic-bridge.json
+++ b/content/blocks/liquid/benthic-bridge.json
@@ -1,5 +1,6 @@
 {
-  "category": "LiquidBridge",
+  "type": "LiquidBridge",
+  "category": "liquid",
   "name": "Benthic Bridge",
   "requirements": [
     {"item": "bismuth", "amount": 6},

--- a/content/blocks/liquid/benthic-junction.json
+++ b/content/blocks/liquid/benthic-junction.json
@@ -1,6 +1,7 @@
 {
+  "type": "LiquidJunction",
   "name": "Benthic Junction",
-  "category": "LiquidJunction",
+  "category": "liquid",
   "requirements":[
     {"item": "ashstone", "amount": 2}
   ],

--- a/content/blocks/liquid/benthic-router.json
+++ b/content/blocks/liquid/benthic-router.json
@@ -1,6 +1,7 @@
 {
+  "type": "LiquidRouter",
   "name": "Benthic Router",
-  "category": "LiquidRouter",
+  "category": "liquid",
   "requirements":[
     {"item": "ashstone", "amount": 2}
   ],


### PR DESCRIPTION
In the liquid blocks you used this code.
```json
"category": "Liquid[Sub Type]"
```
This caused an error because `category` is for the category the block will be found in the block selection menu. On the  official mindustry wiki there is a [list of categories](https://mindustrygame.github.io/wiki/modding/5-types/#category).

You are trying to specify `type` there.

If you want to specify the `type` of a block use this field.
```json
"type": "[Block Type]"
```